### PR TITLE
Add 'lazy_mode' & signature_exists with test and doc + some small fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ META.json
 META.yml
 MYMETA.*
 *.swp
+*.bbprojectd
+.DS_Store

--- a/dist.ini
+++ b/dist.ini
@@ -24,4 +24,4 @@ mb_version = 0.38
 cpan = 1
 [GitHub::Meta]
 [ReadmeFromPod]
-[ChangesTests]
+[Test::CPAN::Changes]

--- a/t/01-functional.t
+++ b/t/01-functional.t
@@ -30,7 +30,7 @@ plugin 'authentication', {
         my $password = shift || '';
         my $extradata = shift || {};
 
-        return 'useridwithextradata' if($username eq 'foo' && $password eq 'bar' && $extradata->{'ohnoes'} eq 'itsameme');
+        return 'useridwithextradata' if($username eq 'foo' && $password eq 'bar' && ( $extradata->{'ohnoes'} || '' ) eq 'itsameme');
         return 'userid' if($username eq 'foo' && $password eq 'bar');
         return undef;
     },

--- a/t/02-functional_lazy.t
+++ b/t/02-functional_lazy.t
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+# Disable IPv6, epoll and kqueue
+BEGIN { $ENV{MOJO_NO_IPV6} = $ENV{MOJO_POLL} = 1 }
+
+use Test::More;
+plan tests => 38;
+
+# testing code starts here
+use Mojolicious::Lite;
+use Test::Mojo;
+
+plugin 'authentication', {
+    lazy_mode => 1,
+    load_user => sub {
+        my $self = shift;
+        my $uid  = shift;
+
+        return {
+            'username' => 'foo',
+            'password' => 'bar',
+            'name'     => 'Foo'
+          }
+          if ( $uid eq 'userid' );
+        return undef;
+    },
+    validate_user => sub {
+        my $self      = shift;
+        my $username  = shift || '';
+        my $password  = shift || '';
+        my $extradata = shift || {};
+
+        return 'userid' if ( $username eq 'foo' && $password eq 'bar' );
+        return undef;
+    },
+};
+
+get '/' => sub {
+    my $self = shift;
+    $self->render( text => 'index page' );
+};
+
+post '/login' => sub {
+    my $self = shift;
+    my $u    = $self->req->param('u');
+    my $p    = $self->req->param('p');
+
+    $self->render(
+        text => ( $self->authenticate( $u, $p ) ) ? 'ok' : 'failed' );
+};
+
+get '/authonly' => sub {
+    my $self = shift;
+    $self->render( text => ( $self->user_exists )
+        ? 'authenticated'
+        : 'not authenticated' );
+};
+
+get '/condition/authonly' => ( authenticated => 1 ) => sub {
+    my $self = shift;
+    $self->render( text => 'authenticated condition' );
+};
+
+get '/authonly/lazy' => sub {
+    my $self = shift;
+    $self->render( text => ( $self->signature_exists )
+        ? 'sign authenticated'
+        : 'sign not authenticated' );
+};
+
+get '/condition/authonly/lazy' => ( signed => 1 ) => sub {
+    my $self = shift;
+    $self->render( text => 'signed authenticated condition' );
+};
+
+get '/logout' => sub {
+    my $self = shift;
+
+    $self->logout();
+    $self->render( text => 'logout' );
+};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/')->status_is(200)->content_is('index page');
+$t->get_ok('/authonly/lazy')->status_is(200)
+  ->content_is('sign not authenticated');
+$t->get_ok('/condition/authonly/lazy')->status_is(404);
+
+# let's try this
+$t->post_form_ok( '/login', { u => 'fnark', p => 'fnork' } )->status_is(200)
+  ->content_is('failed');
+$t->get_ok('/authonly')->status_is(200)->content_is('not authenticated');
+
+$t->post_form_ok( '/login', { u => 'foo', p => 'bar' } )->status_is(200)
+  ->content_is('ok');
+
+# try original auth in lazy mode
+$t->get_ok('/authonly')->status_is(200)->content_is('authenticated');
+$t->get_ok('/condition/authonly')->status_is(200)
+  ->content_is('authenticated condition');
+
+# try lazy auth - is user just signed
+$t->get_ok('/authonly/lazy')->status_is(200)->content_is('sign authenticated');
+$t->get_ok('/condition/authonly/lazy')->status_is(200)
+  ->content_is('signed authenticated condition');
+
+$t->get_ok('/logout')->status_is(200)->content_is('logout');
+$t->get_ok('/authonly')->status_is(200)->content_is('not authenticated');
+$t->get_ok('/authonly/lazy')->status_is(200)
+  ->content_is('sign not authenticated');


### PR DESCRIPTION
Hi!

I think this module may have less strict and more fast method 'signature_exists' - its just check $c->session($session_key). Non-secure, but for fast lookup and devision 'like guest'/'like user'.

Also I add 'lazy_mode' to wipe 'before_dispatch' hook. It seems a little bit expensive to read user data at ANY request. On the contrary in lazy_mode user data to be loaded on firs call. If site have many public pages it`s may improve speed and reduce DB reading.

I add some docs and test. All ok with test, but docs may need some fix - english is`nt my mother tongue.
