### PR TITLE
Implements new parameter to control response from routing via condition

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -63,6 +63,8 @@ The following options can be set for the plugin:
 
 =item current_user_fn (optional) Set the name for the current_user() helper function
 
+=item fail_render (optional) The hashref passed to L<Mojolicious::Controller/render> function used when routing L</"ROUTING VIA CONDITION"> fails.
+
 =back
 
 In order to set the session expiry time, use the following in your startup routine:
@@ -115,6 +117,11 @@ And another condition for fast and unsecured checking for users, having a signat
     $r->route('/foo')->over(signed => 1)->to('mycontroller#foo');
 
 This behavior is similar to the "authenticated" condition.
+
+If you want to control what's sent to the client when the condition fails, you can use the C<fail_render> parameter with a value similar to this:
+
+    fail_render => { status => 401, json => { message => 'Unauthorized' } }
+
 
 =head1 ROUTING VIA CALLBACK
 

--- a/README.pod
+++ b/README.pod
@@ -15,7 +15,7 @@ Mojolicious::Plugin::Authentication - A plugin to make authentication a bit easi
     });
 
     if ($self->authenticate('username', 'password', { optional => 'extra data stuff' })) {
-        ... 
+        ...
     }
 
 
@@ -63,7 +63,7 @@ The following options can be set for the plugin:
 
 =item current_user_fn (optional) Set the name for the current_user() helper function
 
-=back 
+=back
 
 In order to set the session expiry time, use the following in your startup routine:
 
@@ -75,7 +75,7 @@ In order to set the session expiry time, use the following in your startup routi
 
 The coderef you pass to the load_user configuration key has the following signature:
 
-    sub { 
+    sub {
         my ($app, $uid) = @_;
         ...
         return $user;
@@ -93,7 +93,7 @@ User validation is what happens when we need to authenticate someone. The codere
         return $uid;
     }
 
-You must return either a user id or undef. The user id can be numerical or a string. Do not return hashrefs, arrayrefs or objects, since the behaviour of this plugin could get a little bit on the odd side of weird if you do that. 
+You must return either a user id or undef. The user id can be numerical or a string. Do not return hashrefs, arrayrefs or objects, since the behaviour of this plugin could get a little bit on the odd side of weird if you do that.
 
 =head1 EXAMPLES
 
@@ -108,7 +108,7 @@ This plugin also exports a routing condition you can use in order to limit acces
     my $authenticated_only = $r->route('/members')->over(authenticated => 1)->to('members#index');
     $authenticated_only->route('online')->to('members#online');
 
-If someone is not authenticated, these routes will not be considered by the dispatcher and unless you have set up a catch-all route, a 404 Not Found will be generated instead. 
+If someone is not authenticated, these routes will not be considered by the dispatcher and unless you have set up a catch-all route, a 404 Not Found will be generated instead.
 
 And another condition for fast and unsecured checking for users, having a signature (without validating it). This method just checks client cookies for uid data existing.
 
@@ -202,10 +202,10 @@ L<http://search.cpan.org/dist/Mojolicious-Plugin-Authentication/>
 
 =head1 ACKNOWLEDGEMENTS
 
-Andrew Parker   
+Andrew Parker
     -   For pointing out some bugs that crept in; a silent reminder not to code while sleepy
 
-Mirko Westermeier (memowe) 
+Mirko Westermeier (memowe)
     -   For doing some (much needed) code cleanup
 
 Terrence Brannon (metaperl)
@@ -223,7 +223,7 @@ Ed W
         a bit more sane.
 
 SailingYYC (Github)
-    -   For reporting an issue with routing conditions; I really should not code while sleepy, brainfarts imminent! 
+    -   For reporting an issue with routing conditions; I really should not code while sleepy, brainfarts imminent!
 
 carragom (Github)
     -   For fixing the bug that'd consider an uid of 0 or "0" to be a problem

--- a/lib/Mojolicious/Plugin/Authentication.pm
+++ b/lib/Mojolicious/Plugin/Authentication.pm
@@ -158,7 +158,7 @@ Mojolicious::Plugin::Authentication - A plugin to make authentication a bit easi
     });
 
     if ($self->authenticate('username', 'password', { optional => 'extra data stuff' })) {
-        ... 
+        ...
     }
 
 
@@ -206,7 +206,7 @@ The following options can be set for the plugin:
 
 =item current_user_fn (optional) Set the name for the current_user() helper function
 
-=back 
+=back
 
 In order to set the session expiry time, use the following in your startup routine:
 
@@ -218,7 +218,7 @@ In order to set the session expiry time, use the following in your startup routi
 
 The coderef you pass to the load_user configuration key has the following signature:
 
-    sub { 
+    sub {
         my ($app, $uid) = @_;
         ...
         return $user;
@@ -236,7 +236,7 @@ User validation is what happens when we need to authenticate someone. The codere
         return $uid;
     }
 
-You must return either a user id or undef. The user id can be numerical or a string. Do not return hashrefs, arrayrefs or objects, since the behaviour of this plugin could get a little bit on the odd side of weird if you do that. 
+You must return either a user id or undef. The user id can be numerical or a string. Do not return hashrefs, arrayrefs or objects, since the behaviour of this plugin could get a little bit on the odd side of weird if you do that.
 
 =head1 EXAMPLES
 
@@ -251,7 +251,7 @@ This plugin also exports a routing condition you can use in order to limit acces
     my $authenticated_only = $r->route('/members')->over(authenticated => 1)->to('members#index');
     $authenticated_only->route('online')->to('members#online');
 
-If someone is not authenticated, these routes will not be considered by the dispatcher and unless you have set up a catch-all route, a 404 Not Found will be generated instead. 
+If someone is not authenticated, these routes will not be considered by the dispatcher and unless you have set up a catch-all route, a 404 Not Found will be generated instead.
 
 And another condition for fast and unsecured checking for users, having a signature (without validating it). This method just checks client cookies for uid data existing.
 
@@ -345,10 +345,10 @@ L<http://search.cpan.org/dist/Mojolicious-Plugin-Authentication/>
 
 =head1 ACKNOWLEDGEMENTS
 
-Andrew Parker   
+Andrew Parker
     -   For pointing out some bugs that crept in; a silent reminder not to code while sleepy
 
-Mirko Westermeier (memowe) 
+Mirko Westermeier (memowe)
     -   For doing some (much needed) code cleanup
 
 Terrence Brannon (metaperl)
@@ -366,7 +366,7 @@ Ed W
         a bit more sane.
 
 SailingYYC (Github)
-    -   For reporting an issue with routing conditions; I really should not code while sleepy, brainfarts imminent! 
+    -   For reporting an issue with routing conditions; I really should not code while sleepy, brainfarts imminent!
 
 carragom (Github)
     -   For fixing the bug that'd consider an uid of 0 or "0" to be a problem

--- a/lib/Mojolicious/Plugin/Authentication.pm
+++ b/lib/Mojolicious/Plugin/Authentication.pm
@@ -24,6 +24,7 @@ sub register {
     my $load_user_cb      = $args->{load_user};
     my $validate_user_cb  = $args->{validate_user};
     my $current_user_fn   = $args->{current_user_fn} || 'current_user';
+    my $fail_render       = $args->{fail_render};
 
     # Unconditionally load the user based on uid in session
     my $user_loader_sub = sub {
@@ -67,7 +68,9 @@ sub register {
 
     $app->routes->add_condition(authenticated => sub {
         my ($r, $c, $captures, $required) = @_;
-        return (!$required || $c->is_user_authenticated) ? 1 : 0;
+        my $res = (!$required || $c->is_user_authenticated) ? 1 : 0;
+        $c->render(%$fail_render) if $fail_render && !$res;
+        return $res;
     });
 
     $app->routes->add_condition(signed => sub {


### PR DESCRIPTION
This implements a new configuration parameter `fail_render`. The idea is to easily control what will be rendered to the client in case the routing via condition fails. This parameter also exists in [Mojolicious-Plugin-Authorization](https://metacpan.org/pod/Mojolicious::Plugin::Authorization#SYNOPSIS) so I guess using the same name makes sense. The parameter is optional and the default behavior is used if not defined.

Not sure if there is a less verbose way to handle the testing.
Let me know what you think.
Thanks.