### PR TITLE
allow setting current_user via argument

### DIFF
--- a/lib/Mojolicious/Plugin/Authentication.pm
+++ b/lib/Mojolicious/Plugin/Authentication.pm
@@ -47,6 +47,12 @@ sub register {
     my $user_stash_extractor_sub = sub {
         my $c = shift;
 
+        # Allow setting the current_user
+        if ( @_ ) {
+            $c->stash($our_stash_key => { user => $_[0] });
+            return;
+        }
+
         if ( !(
                 defined($c->stash($our_stash_key))
                 && ($c->stash($our_stash_key)->{no_user}
@@ -90,8 +96,7 @@ sub register {
     });
 
     my $current_user = sub {
-        my $c = shift;
-        return $user_stash_extractor_sub->($c);
+        return $user_stash_extractor_sub->(@_);
     };
 
     $app->helper(reload_user => sub {
@@ -178,6 +183,11 @@ Returns true if current_user() returns some valid object, false otherwise.
 =head2 current_user
 
 Returns the user object as it was returned from the supplied C<load_user> subroutine ref.
+
+You can change the current user by passing it in, but be careful: This
+bypasses the authentication. This is useful if you have multiple ways to
+authenticate users and want to re-use authorization checks that use
+C<current_user>.
 
 =head2 reload_user
 

--- a/t/03-current_user.t
+++ b/t/03-current_user.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+# Disable IPv6, epoll and kqueue
+BEGIN { $ENV{MOJO_NO_IPV6} = $ENV{MOJO_POLL} = 1 }
+
+use Test::More;
+plan tests => 6;
+
+# testing code starts here
+use Mojolicious::Lite;
+use Test::Mojo;
+
+plugin 'authentication', {
+    autoload_user => 1,
+    load_user => sub {
+        my $self = shift;
+        my $uid  = shift;
+
+        return {
+            'username' => 'foo',
+            'password' => 'bar',
+            'name'     => 'Foo'
+            } if($uid eq 'userid' || $uid eq 'useridwithextradata');
+        return undef;
+    },
+    validate_user => sub {
+        my $self = shift;
+        my $username = shift || '';
+        my $password = shift || '';
+        my $extradata = shift || {};
+
+        return 'useridwithextradata' if($username eq 'foo' && $password eq 'bar' && ( $extradata->{'ohnoes'} || '' ) eq 'itsameme');
+        return 'userid' if($username eq 'foo' && $password eq 'bar');
+        return undef;
+    },
+};
+
+get '/other/endpoint' => sub {
+    my $self = shift;
+    $self->authenticate( 'foo', 'bar' );
+    $self->render( text => $self->current_user->{username} );
+};
+
+under '/api' => sub {
+    my $self = shift;
+    $self->current_user( { username => 'custom' } );
+    return 1;
+};
+
+get '/endpoint' => sub {
+    my $self = shift;
+    $self->render( text => $self->current_user->{username} );
+};
+
+my $t = Test::Mojo->new;
+$t->get_ok( '/other/endpoint' )->status_is( 200 )->content_is( 'foo' );
+$t->get_ok( '/api/endpoint' )->status_is( 200 )->content_is( 'custom' );
+


### PR DESCRIPTION
This allows us to have multiple authentication methods, but re-use the
authorization / permission helpers that use the `current_user` helper to
decide what to do.

Fixes #16
