### PR TITLE
Do not call validate_user when auto_validate is present. Fix #23

### DIFF
--- a/lib/Mojolicious/Plugin/Authentication.pm
+++ b/lib/Mojolicious/Plugin/Authentication.pm
@@ -123,17 +123,15 @@ sub register {
     $app->helper(authenticate => sub {
         my ($c, $user, $pass, $extradata) = @_;
 
-        $extradata ||= {};
-        my $uid = $validate_user_cb->($c, $user, $pass, $extradata);
-
         # if extradata contains "auto_validate", assume the passed username is in fact valid, and
         # auto_validate contains the uid; used for oAuth and other stuff that does not work with
         # usernames and passwords; use this with extreme care if you must
-        if(defined($extradata->{auto_validate})) {
-            $c->session($session_key => $extradata->{auto_validate});
-            delete $c->stash->{$our_stash_key};
-            return 1 if defined( $current_user->($c) );
-        } elsif (defined($uid)) {
+
+        $extradata ||= {};
+        my $uid = $extradata->{auto_validate} //
+          $validate_user_cb->($c, $user, $pass, $extradata);
+
+        if(defined($uid)) {
             $c->session($session_key => $uid);
             # Clear stash to force reload of any already loaded user object
             delete $c->stash->{$our_stash_key};


### PR DESCRIPTION
This merge request simplifies the code in `authenticate` so that the `validate_user` callback is never called when `auto_validate` is present in the extradata hash, as stated in the documentation.
